### PR TITLE
Update git clone URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ To get a development environment to run, follow these steps:
 #. Clone the repo and start the containers:
     .. code-block:: bash
 
-        git clone git@git.magenta.dk:os2datascanner/os2datascanner.git
+        git clone https://github.com/os2datascanner/os2datascanner.git
         cd os2datascanner
         docker-compose up -d
 


### PR DESCRIPTION
I love the  clear  README file. I noticed the repository git.magenta.dk:os2datascanner/os2datascanner.git  refered in the README is either inaccessible or unavailable.
I would like to propose to update the URL to this repository:  git clone https://github.com/os2datascanner/os2datascanner.git so first time users trying out have an even smoother first try.